### PR TITLE
Changes for metadata fields, Params to Args

### DIFF
--- a/eems_online_app/static/deps/mpilot/MPilotEEMSBasicLib.py
+++ b/eems_online_app/static/deps/mpilot/MPilotEEMSBasicLib.py
@@ -21,12 +21,12 @@ class Copy(mpefp._MPilotEEMSFxnParent):
         self.fxnDesc['ShortDesc'] = 'Copies the data from another field'
         self.fxnDesc['ReturnType'] = 'Any'
         
-        self.fxnDesc['ReqParams'] = {
+        self.fxnDesc['ReqArgs'] = {
             'InFieldName':'Field Name'
             }
-        self.fxnDesc['OptParams'] = {
+        self.fxnDesc['OptArgs'] = {
             'OutFileName':'File Name',
-            'MetaData':'Any',
+            'Metadata':'Any',
             'PrecursorFieldNames':['Field Name','Field Name List']
             }
         
@@ -34,15 +34,15 @@ class Copy(mpefp._MPilotEEMSFxnParent):
 
     def DependencyNms(self):
         
-        rtrn = self._ParamToList('InFieldName')
-        rtrn += self._ParamToList('PrecursorFieldNames')
+        rtrn = self._ArgToList('InFieldName')
+        rtrn += self._ArgToList('PrecursorFieldNames')
         return rtrn
     
     # def DependencyNms(self):
         
     def Exec(self,executedObjects):
 
-        fldNmObj = executedObjects[self.ValFromParamByNm('InFieldName')]
+        fldNmObj = executedObjects[self.ValFromArgByNm('InFieldName')]
         self.execRslt = cp.deepcopy(fldNmObj.ExecRslt())
         self.dataType = fldNmObj.DataType()
         self.isDataLayer = fldNmObj.IsDataLayer()
@@ -76,13 +76,13 @@ class AMinusB(mpefp._MPilotEEMSFxnParent):
             'Positive Float'
             ]                        
         
-        self.fxnDesc['ReqParams'] = {
+        self.fxnDesc['ReqArgs'] = {
             'A':'Field Name',
             'B':'Field Name'
             }
-        self.fxnDesc['OptParams'] = {
+        self.fxnDesc['OptArgs'] = {
             'OutFileName':'File Name',
-            'MetaData':'Any',
+            'Metadata':'Any',
             'PrecursorFieldNames':['Field Name','Field Name List']
             }
         
@@ -90,17 +90,17 @@ class AMinusB(mpefp._MPilotEEMSFxnParent):
 
     def DependencyNms(self):
         
-        rtrn = self._ParamToList('A')
-        rtrn += self._ParamToList('B')
-        rtrn += self._ParamToList('PrecursorFieldNames')
+        rtrn = self._ArgToList('A')
+        rtrn += self._ArgToList('B')
+        rtrn += self._ArgToList('PrecursorFieldNames')
         return rtrn
     
     # def DependencyNms(self):
     
     def Exec(self,executedObjects):
 
-        aObj = executedObjects[self.ValFromParamByNm('A')]
-        bObj = executedObjects[self.ValFromParamByNm('B')]
+        aObj = executedObjects[self.ValFromArgByNm('A')]
+        bObj = executedObjects[self.ValFromArgByNm('B')]
         
         self._ValidateIsDataLayer(aObj)
         self._ValidateIsDataLayer(bObj)
@@ -162,12 +162,12 @@ class Sum(mpefp._MPilotEEMSFxnParent):
             'Positive Float'
             ]                        
 
-        self.fxnDesc['ReqParams'] = {
+        self.fxnDesc['ReqArgs'] = {
             'InFieldNames':['Field Name List']
             }
-        self.fxnDesc['OptParams'] = {
+        self.fxnDesc['OptArgs'] = {
             'OutFileName':'File Name',
-            'MetaData':'Any',
+            'Metadata':'Any',
             'PrecursorFieldNames':['Field Name','Field Name List']
             }
         
@@ -177,7 +177,7 @@ class Sum(mpefp._MPilotEEMSFxnParent):
         # executedObjects is a dictionary of executed MPilot function objects
         
         self._ValidateListLen('InFldNms',1)
-        fldNms = self._ParamToList('InFieldNames')
+        fldNms = self._ArgToList('InFieldNames')
 
         # Validate input data and gather types
         inDataTypes = {}
@@ -239,13 +239,13 @@ class WeightedSum(mpefp._MPilotEEMSFxnParent):
             'Positive Float'
             ]                        
 
-        self.fxnDesc['ReqParams'] = {
+        self.fxnDesc['ReqArgs'] = {
             'InFieldNames':['Field Name List'],
             'Weights':['Float','Float List']            
             }
-        self.fxnDesc['OptParams'] = {
+        self.fxnDesc['OptArgs'] = {
             'OutFileName':'File Name',
-            'MetaData':'Any',
+            'Metadata':'Any',
             'PrecursorFieldNames':['Field Name','Field Name List']
             }
         
@@ -257,8 +257,8 @@ class WeightedSum(mpefp._MPilotEEMSFxnParent):
         self._ValidateListLen('InFldNms',1)
         self._ValidateEqualListLens(['InFieldNames','Weights'])
         
-        fldNms = self._ParamToList('InFieldNames')
-        wts = self.ValFromParamByNm('Weights')
+        fldNms = self._ArgToList('InFieldNames')
+        wts = self.ValFromArgByNm('Weights')
 
         # Validate input data and gather types
         for fldNm in fldNms:
@@ -313,12 +313,12 @@ class Multiply(mpefp._MPilotEEMSFxnParent):
             'Positive Float'
             ]                        
 
-        self.fxnDesc['ReqParams'] = {
+        self.fxnDesc['ReqArgs'] = {
             'InFieldNames':['Field Name List']
             }
-        self.fxnDesc['OptParams'] = {
+        self.fxnDesc['OptArgs'] = {
             'OutFileName':'File Name',
-            'MetaData':'Any',
+            'Metadata':'Any',
             'PrecursorFieldNames':['Field Name','Field Name List']
             }
         
@@ -328,7 +328,7 @@ class Multiply(mpefp._MPilotEEMSFxnParent):
         # executedObjects is a dictionary of executed MPilot function objects
         
         self._ValidateListLen('InFldNms',1)
-        fldNms = self._ParamToList('InFieldNames')
+        fldNms = self._ArgToList('InFieldNames')
 
         # Validate input data and gather types
         inDataTypes = {}
@@ -387,13 +387,13 @@ class ADividedByB(mpefp._MPilotEEMSFxnParent):
             'Positive Float'
             ]                        
         
-        self.fxnDesc['ReqParams'] = {
+        self.fxnDesc['ReqArgs'] = {
             'A':'Field Name',
             'B':'Field Name'
             }
-        self.fxnDesc['OptParams'] = {
+        self.fxnDesc['OptArgs'] = {
             'OutFileName':'File Name',
-            'MetaData':'Any',
+            'Metadata':'Any',
             'PrecursorFieldNames':['Field Name','Field Name List']
             }
         
@@ -401,17 +401,17 @@ class ADividedByB(mpefp._MPilotEEMSFxnParent):
 
     def DependencyNms(self):
         
-        rtrn = self._ParamToList('A')
-        rtrn += self._ParamToList('B')
-        rtrn += self._ParamToList('PrecursorFieldNames')
+        rtrn = self._ArgToList('A')
+        rtrn += self._ArgToList('B')
+        rtrn += self._ArgToList('PrecursorFieldNames')
         return rtrn
     
     # def DependencyNms(self):
     
     def Exec(self,executedObjects):
 
-        aObj = executedObjects[self.ValFromParamByNm('A')]
-        bObj = executedObjects[self.ValFromParamByNm('B')]
+        aObj = executedObjects[self.ValFromArgByNm('A')]
+        bObj = executedObjects[self.ValFromArgByNm('B')]
         
         self._ValidateIsDataLayer(aObj)
         self._ValidateIsDataLayer(bObj)
@@ -463,12 +463,12 @@ class Minimum(mpefp._MPilotEEMSFxnParent):
             'Positive Float'
             ]
         
-        self.fxnDesc['ReqParams'] = {
+        self.fxnDesc['ReqArgs'] = {
             'InFieldNames':['Field Name','Field Name List']
             }
-        self.fxnDesc['OptParams'] = {
+        self.fxnDesc['OptArgs'] = {
             'OutFileName':'File Name',
-            'MetaData':'Any',
+            'Metadata':'Any',
             'PrecursorFieldNames':['Field Name','Field Name List']
             }
         
@@ -477,7 +477,7 @@ class Minimum(mpefp._MPilotEEMSFxnParent):
     def Exec(self,executedObjects):
 
         self._ValidateListLen('InFldNms',1)
-        fldNms = self._ParamToList('InFieldNames')
+        fldNms = self._ArgToList('InFieldNames')
         
         # Validate input data and gather types
         inDataTypes = {}
@@ -537,12 +537,12 @@ class Maximum(mpefp._MPilotEEMSFxnParent):
             'Positive Float'
             ]
         
-        self.fxnDesc['ReqParams'] = {
+        self.fxnDesc['ReqArgs'] = {
             'InFieldNames':['Field Name','Field Name List']
             }
-        self.fxnDesc['OptParams'] = {
+        self.fxnDesc['OptArgs'] = {
             'OutFileName':'File Name',
-            'MetaData':'Any',
+            'Metadata':'Any',
             'PrecursorFieldNames':['Field Name','Field Name List']
             }
         
@@ -551,7 +551,7 @@ class Maximum(mpefp._MPilotEEMSFxnParent):
     def Exec(self,executedObjects):
 
         self._ValidateListLen('InFldNms',1)
-        fldNms = self._ParamToList('InFieldNames')
+        fldNms = self._ArgToList('InFieldNames')
         
         # Validate input data and gather types
         inDataTypes = {}
@@ -612,12 +612,12 @@ class Mean(mpefp._MPilotEEMSFxnParent):
             'Positive Float'
             ]                        
 
-        self.fxnDesc['ReqParams'] = {
+        self.fxnDesc['ReqArgs'] = {
             'InFieldNames':['Field Name List']
             }
-        self.fxnDesc['OptParams'] = {
+        self.fxnDesc['OptArgs'] = {
             'OutFileName':'File Name',
-            'MetaData':'Any',
+            'Metadata':'Any',
             'PrecursorFieldNames':['Field Name','Field Name List']
             }
         
@@ -627,7 +627,7 @@ class Mean(mpefp._MPilotEEMSFxnParent):
         # executedObjects is a dictionary of executed MPilot function objects
         
         self._ValidateListLen('InFldNms',1)
-        fldNms = self._ParamToList('InFieldNames')
+        fldNms = self._ArgToList('InFieldNames')
 
         # Validate input data and gather types
         inDataTypes = {}
@@ -685,13 +685,13 @@ class WeightedMean(mpefp._MPilotEEMSFxnParent):
             'Positive Float'
             ]                        
 
-        self.fxnDesc['ReqParams'] = {
+        self.fxnDesc['ReqArgs'] = {
             'InFieldNames':['Field Name List'],
             'Weights':['Float','Float List']            
             }
-        self.fxnDesc['OptParams'] = {
+        self.fxnDesc['OptArgs'] = {
             'OutFileName':'File Name',
-            'MetaData':'Any',
+            'Metadata':'Any',
             'PrecursorFieldNames':['Field Name','Field Name List']
             }
         
@@ -703,8 +703,8 @@ class WeightedMean(mpefp._MPilotEEMSFxnParent):
         self._ValidateListLen('InFldNms',1)
         self._ValidateEqualListLens(['InFieldNames','Weights'])
         
-        fldNms = self._ParamToList('InFieldNames')
-        wts = self.ValFromParamByNm('Weights')
+        fldNms = self._ArgToList('InFieldNames')
+        wts = self.ValFromArgByNm('Weights')
 
         # Validate input data and gather types
         for fldNm in fldNms:
@@ -756,14 +756,14 @@ class Normalize(mpefp._MPilotEEMSFxnParent):
             'Positive Float'
             ]                        
         
-        self.fxnDesc['ReqParams'] = {
+        self.fxnDesc['ReqArgs'] = {
             'InFieldName':'Field Name'
             }
-        self.fxnDesc['OptParams'] = {
+        self.fxnDesc['OptArgs'] = {
             'StartVal':'Float',
             'EndVal':'Float',
             'OutFileName':'File Name',
-            'MetaData':'Any',
+            'Metadata':'Any',
             'PrecursorFieldNames':['Field Name','Field Name List']
             }
         
@@ -771,19 +771,19 @@ class Normalize(mpefp._MPilotEEMSFxnParent):
 
     def DependencyNms(self):
         
-        rtrn = self._ParamToList('InFieldName')
-        rtrn += self._ParamToList('PrecursorFieldNames')
+        rtrn = self._ArgToList('InFieldName')
+        rtrn += self._ArgToList('PrecursorFieldNames')
         return rtrn
     
     # def DependencyNms(self):
         
     def Exec(self,executedObjects):
 
-        inObj = executedObjects[self.ValFromParamByNm('InFieldName')]
+        inObj = executedObjects[self.ValFromArgByNm('InFieldName')]
         self._ValidateIsDataLayer(inObj)
         
-        startVal = self.ValFromParamByNm('StartVal')
-        endVal = self.ValFromParamByNm('EndVal')
+        startVal = self.ValFromArgByNm('StartVal')
+        endVal = self.ValFromArgByNm('EndVal')
         if startVal is None: startVal = 0.0
         if endVal is None: endVal = 1.0
 

--- a/eems_online_app/static/deps/mpilot/MPilotEEMSFuzzyLogicLib.py
+++ b/eems_online_app/static/deps/mpilot/MPilotEEMSFuzzyLogicLib.py
@@ -24,14 +24,14 @@ class CvtToFuzzy(mpefp._MPilotEEMSFxnParent):
         self.fxnDesc['ShortDesc'] = 'Converts input values into fuzzy values using linear interpolation'
         self.fxnDesc['ReturnType'] = 'Fuzzy'
 
-        self.fxnDesc['ReqParams'] = {
+        self.fxnDesc['ReqArgs'] = {
             'InFieldName':'Field Name'
             }
-        self.fxnDesc['OptParams'] = {
+        self.fxnDesc['OptArgs'] = {
             'TrueThreshold':'Float',
             'FalseThreshold':'Float',
             'OutFileName':'File Name',
-            'MetaData':'Any',
+            'Metadata':'Any',
             'PrecursorFieldNames':['Field Name','Field Name List'],
             'Direction':'Any',
             }
@@ -40,8 +40,8 @@ class CvtToFuzzy(mpefp._MPilotEEMSFxnParent):
 
     def DependencyNms(self):
         
-        rtrn = self._ParamToList('InFieldName')
-        rtrn += self._ParamToList('PrecursorFieldNames')
+        rtrn = self._ArgToList('InFieldName')
+        rtrn += self._ArgToList('PrecursorFieldNames')
         return rtrn
     
     # def DependencyNms(self):
@@ -49,7 +49,7 @@ class CvtToFuzzy(mpefp._MPilotEEMSFxnParent):
     def Exec(self,executedObjects):
         # executedObjects is a dictionary of executed MPilot function objects
         
-        inFldNm = self.ParamByNm('InFieldName')
+        inFldNm = self.ArgByNm('InFieldName')
         inObj = executedObjects[inFldNm]
         
         self._ValidateProgDataType(
@@ -68,8 +68,8 @@ class CvtToFuzzy(mpefp._MPilotEEMSFxnParent):
         
         inArr = inObj.ExecRslt()
 
-        if 'Direction' in self.Params():
-            if self.ParamByNm('Direction') not in ['LowToHigh','HighToLow']:
+        if 'Direction' in self.Args():
+            if self.ArgByNm('Direction') not in ['LowToHigh','HighToLow']:
                 raise Exception(
                     '{}{}{}{}{}{}{}'.format(
                         '\n********************ERROR********************\n',
@@ -85,22 +85,22 @@ class CvtToFuzzy(mpefp._MPilotEEMSFxnParent):
                     ),
                 )
 
-        # if 'Direction' in self.Params():
+        # if 'Direction' in self.Args():
 
-        if 'FalseThreshold' in self.Params():
-            falseThresh = self.ParamByNm('FalseThreshold')
-        elif 'Direction' in self.Params():
-            if self.ParamByNm('Direction') in ['LowToHigh']:
+        if 'FalseThreshold' in self.Args():
+            falseThresh = self.ArgByNm('FalseThreshold')
+        elif 'Direction' in self.Args():
+            if self.ArgByNm('Direction') in ['LowToHigh']:
                 falseThresh =  inArr.min()
-            elif self.ParamByNm('Direction') in ['HighToLow']:
+            elif self.ArgByNm('Direction') in ['HighToLow']:
                 falseThresh =  inArr.max()
                 
-        if 'TrueThreshold' in self.Params():
-            trueThresh = self.ParamByNm('TrueThreshold')
-        elif 'Direction' in self.Params():
-            if self.ParamByNm('Direction') in ['LowToHigh']:
+        if 'TrueThreshold' in self.Args():
+            trueThresh = self.ArgByNm('TrueThreshold')
+        elif 'Direction' in self.Args():
+            if self.ArgByNm('Direction') in ['LowToHigh']:
                 trueThresh =  inArr.max()
-            elif self.ParamByNm('Direction') in ['HighToLow']:
+            elif self.ArgByNm('Direction') in ['HighToLow']:
                 trueThresh =  inArr.min()
 
         if trueThresh == falseThresh:
@@ -152,15 +152,15 @@ class CvtToFuzzyCat(mpefp._MPilotEEMSFxnParent):
         self.fxnDesc['ShortDesc'] = 'Converts integer input values into fuzzy based on user specification.'
         self.fxnDesc['ReturnType'] = 'Fuzzy'
 
-        self.fxnDesc['ReqParams'] = {
+        self.fxnDesc['ReqArgs'] = {
             'InFieldName':'Field Name',
             'RawValues':['Integer List'],
             'FuzzyValues':['Fuzzy Value List'],
             'DefaultFuzzyValue':'Fuzzy Value',
             }
-        self.fxnDesc['OptParams'] = {
+        self.fxnDesc['OptArgs'] = {
             'OutFileName':'File Name',
-            'MetaData':'Any',
+            'Metadata':'Any',
             'PrecursorFieldNames':['Field Name','Field Name List'],
             }
         
@@ -168,8 +168,8 @@ class CvtToFuzzyCat(mpefp._MPilotEEMSFxnParent):
 
     def DependencyNms(self):
         
-        rtrn = self._ParamToList('InFieldName')
-        rtrn += self._ParamToList('PrecursorFieldNames')
+        rtrn = self._ArgToList('InFieldName')
+        rtrn += self._ArgToList('PrecursorFieldNames')
         return rtrn
     
     # def DependencyNms(self):
@@ -177,7 +177,7 @@ class CvtToFuzzyCat(mpefp._MPilotEEMSFxnParent):
     def Exec(self,executedObjects):
         # executedObjects is a dictionary of executed MPilot function objects
         
-        inFldNm = self.ParamByNm('InFieldName')
+        inFldNm = self.ArgByNm('InFieldName')
         inObj = executedObjects[inFldNm]
         
         # Result starts with a copy of the first input field, then add the rest
@@ -194,7 +194,7 @@ class CvtToFuzzyCat(mpefp._MPilotEEMSFxnParent):
             )
 
         self._ValidateEqualListLens(['FuzzyValues','RawValues'])
-        self._ValidateParamListItemsUnique('RawValues')
+        self._ValidateArgListItemsUnique('RawValues')
             
         inArr = inObj.ExecRslt()
         
@@ -203,10 +203,10 @@ class CvtToFuzzyCat(mpefp._MPilotEEMSFxnParent):
             dtype=float
             )
 
-        self.execRslt.data[:] = float(self.ParamByNm('DefaultFuzzyValue'))
+        self.execRslt.data[:] = float(self.ArgByNm('DefaultFuzzyValue'))
 
-        fuzzyVals = self.ValFromParamByNm('FuzzyValues')
-        rawVals = self.ValFromParamByNm('RawValues')
+        fuzzyVals = self.ValFromArgByNm('FuzzyValues')
+        rawVals = self.ValFromArgByNm('RawValues')
         
         for rawVal,fuzzyVal in zip(rawVals,fuzzyVals):
             np.place(self.execRslt.data,inArr.data == rawVal,fuzzyVal)
@@ -241,14 +241,14 @@ class CvtToFuzzyCurve(mpefp._MPilotEEMSFxnParent):
         self.fxnDesc['ShortDesc'] = 'Converts input values into fuzzy based on user-defined curve.'
         self.fxnDesc['ReturnType'] = 'Fuzzy'
 
-        self.fxnDesc['ReqParams'] = {
+        self.fxnDesc['ReqArgs'] = {
             'InFieldName':'Field Name',
             'RawValues':['Float List'],
             'FuzzyValues':['Fuzzy Value List'],
             }
-        self.fxnDesc['OptParams'] = {
+        self.fxnDesc['OptArgs'] = {
             'OutFileName':'File Name',
-            'MetaData':'Any',
+            'Metadata':'Any',
             'PrecursorFieldNames':['Field Name','Field Name List'],
             }
         
@@ -256,8 +256,8 @@ class CvtToFuzzyCurve(mpefp._MPilotEEMSFxnParent):
 
     def DependencyNms(self):
         
-        rtrn = self._ParamToList('InFieldName')
-        rtrn += self._ParamToList('PrecursorFieldNames')
+        rtrn = self._ArgToList('InFieldName')
+        rtrn += self._ArgToList('PrecursorFieldNames')
         return rtrn
     
     # def DependencyNms(self):
@@ -265,7 +265,7 @@ class CvtToFuzzyCurve(mpefp._MPilotEEMSFxnParent):
     def Exec(self,executedObjects):
         # executedObjects is a dictionary of executed MPilot function objects
         
-        inFldNm = self.ParamByNm('InFieldName')
+        inFldNm = self.ArgByNm('InFieldName')
         inObj = executedObjects[inFldNm]
         
         # Result starts with a copy of the first input field, then add the rest
@@ -284,7 +284,7 @@ class CvtToFuzzyCurve(mpefp._MPilotEEMSFxnParent):
             ]
             )
         self._ValidateEqualListLens(['FuzzyValues','RawValues'])
-        self._ValidateParamListItemsUnique('RawValues')
+        self._ValidateArgListItemsUnique('RawValues')
             
         inArr = inObj.ExecRslt()
 
@@ -293,8 +293,8 @@ class CvtToFuzzyCurve(mpefp._MPilotEEMSFxnParent):
             dtype=float
             )
 
-        fuzzyVals = self.ValFromParamByNm('FuzzyValues')
-        rawVals = self.ValFromParamByNm('RawValues')
+        fuzzyVals = self.ValFromArgByNm('FuzzyValues')
+        rawVals = self.ValFromArgByNm('RawValues')
 
         zippedPoints = sorted(zip(rawVals,fuzzyVals))
 
@@ -359,12 +359,12 @@ class FuzzyUnion(mpefp._MPilotEEMSFxnParent):
         self.fxnDesc['ShortDesc'] = 'Takes the fuzzy Union (mean) of fuzzy input variables'
         self.fxnDesc['ReturnType'] = 'Fuzzy'
 
-        self.fxnDesc['ReqParams'] = {
+        self.fxnDesc['ReqArgs'] = {
             'InFieldNames':['Field Name','Field Name List']
             }
-        self.fxnDesc['OptParams'] = {
+        self.fxnDesc['OptArgs'] = {
             'OutFileName':'File Name',
-            'MetaData':'Any',
+            'Metadata':'Any',
             'PrecursorFieldNames':['Field Name','Field Name List']
             }
         
@@ -374,7 +374,7 @@ class FuzzyUnion(mpefp._MPilotEEMSFxnParent):
         # executedObjects is a dictionary of executed MPilot function objects
         
         self._ValidateListLen('InFldNms',1)
-        fldNms = self._ParamToList('InFieldNames')
+        fldNms = self._ArgToList('InFieldNames')
         
         # Result starts with a copy of the first input field, then add the rest
         # and divide by the number of them
@@ -416,13 +416,13 @@ class FuzzyWeightedUnion(mpefp._MPilotEEMSFxnParent):
         self.fxnDesc['ShortDesc'] = 'Takes the weighted fuzzy Union (mean) of fuzzy input variables'
         self.fxnDesc['ReturnType'] = 'Fuzzy'
 
-        self.fxnDesc['ReqParams'] = {
+        self.fxnDesc['ReqArgs'] = {
             'InFieldNames':['Field Name List'],
             'Weights':['Float List']            
             }
-        self.fxnDesc['OptParams'] = {
+        self.fxnDesc['OptArgs'] = {
             'OutFileName':'File Name',
-            'MetaData':'Any',
+            'Metadata':'Any',
             'PrecursorFieldNames':['Field Name','Field Name List']
             }
         
@@ -434,8 +434,8 @@ class FuzzyWeightedUnion(mpefp._MPilotEEMSFxnParent):
         self._ValidateListLen('InFldNms',1)
         self._ValidateEqualListLens(['InFieldNames','Weights'])
         
-        fldNms = self._ParamToList('InFieldNames')
-        wts = self.ValFromParamByNm('Weights')
+        fldNms = self._ArgToList('InFieldNames')
+        wts = self.ValFromArgByNm('Weights')
         
         # Result starts with a copy of the first input field, then add the rest
         # and divide by the number of them
@@ -477,14 +477,14 @@ class FuzzySelectedUnion(mpefp._MPilotEEMSFxnParent):
         self.fxnDesc['ShortDesc'] = 'Takes the fuzzy Union (mean) of N Truest or Falsest fuzzy input variables'
         self.fxnDesc['ReturnType'] = 'Fuzzy'
 
-        self.fxnDesc['ReqParams'] = {
+        self.fxnDesc['ReqArgs'] = {
             'InFieldNames':['Field Name','Field Name List'],
             'TruestOrFalsest':'Truest Or Falsest',
             'NumberToConsider':'Positive Integer'
             }
-        self.fxnDesc['OptParams'] = {
+        self.fxnDesc['OptArgs'] = {
             'OutFileName':'File Name',
-            'MetaData':'Any',
+            'Metadata':'Any',
             'PrecursorFieldNames':['Field Name','Field Name List']
             }
         
@@ -493,8 +493,8 @@ class FuzzySelectedUnion(mpefp._MPilotEEMSFxnParent):
     def Exec(self,executedObjects):
         # executedObjects is a dictionary of executed MPilot function objects
         
-        fldNms = self._ParamToList('InFieldNames')
-        numToCnsdr = self.ValFromParamByNm('NumberToConsider')
+        fldNms = self._ArgToList('InFieldNames')
+        numToCnsdr = self.ValFromArgByNm('NumberToConsider')
         
         if len(fldNms) < numToCnsdr:
             raise Exception(
@@ -536,7 +536,7 @@ class FuzzySelectedUnion(mpefp._MPilotEEMSFxnParent):
             
         stackedArr.sort(axis=0,kind='heapsort')
 
-        if self.ValFromParamByNm('TruestOrFalsest') == 'Truest':
+        if self.ValFromArgByNm('TruestOrFalsest') == 'Truest':
             self.execRslt = np.ma.mean(stackedArr[-numToCnsdr:],axis=0)
         else:
             self.execRslt = np.ma.mean(stackedArr[0:numToCnsdr],axis=0)
@@ -565,12 +565,12 @@ class FuzzyOr(mpefp._MPilotEEMSFxnParent):
         self.fxnDesc['ShortDesc'] = 'Takes the fuzzy Or (maximum) of fuzzy input variables'
         self.fxnDesc['ReturnType'] = 'Fuzzy'
         
-        self.fxnDesc['ReqParams'] = {
+        self.fxnDesc['ReqArgs'] = {
             'InFieldNames':['Field Name','Field Name List']
             }
-        self.fxnDesc['OptParams'] = {
+        self.fxnDesc['OptArgs'] = {
             'OutFileName':'File Name',
-            'MetaData':'Any',
+            'Metadata':'Any',
             'PrecursorFieldNames':['Field Name','Field Name List']
             }
         
@@ -579,7 +579,7 @@ class FuzzyOr(mpefp._MPilotEEMSFxnParent):
     def Exec(self,executedObjects):
 
         self._ValidateListLen('InFldNms',1)
-        fldNms = self._ParamToList('InFieldNames')
+        fldNms = self._ArgToList('InFieldNames')
         
         # Traverse inputs and take maximum
         self._ValidateProgDataType(fldNms[0],executedObjects[fldNms[0]],'Fuzzy')
@@ -616,12 +616,12 @@ class FuzzyAnd(mpefp._MPilotEEMSFxnParent):
         self.fxnDesc['ShortDesc'] = 'Takes the fuzzy And (minimum) of fuzzy input variables'
         self.fxnDesc['ReturnType'] = 'Fuzzy'
         
-        self.fxnDesc['ReqParams'] = {
+        self.fxnDesc['ReqArgs'] = {
             'InFieldNames':['Field Name','Field Name List']
             }
-        self.fxnDesc['OptParams'] = {
+        self.fxnDesc['OptArgs'] = {
             'OutFileName':'File Name',
-            'MetaData':'Any',
+            'Metadata':'Any',
             'PrecursorFieldNames':['Field Name','Field Name List']
             }
         
@@ -630,7 +630,7 @@ class FuzzyAnd(mpefp._MPilotEEMSFxnParent):
     def Exec(self,executedObjects):
 
         self._ValidateListLen('InFldNms',1)
-        fldNms = self._ParamToList('InFieldNames')
+        fldNms = self._ArgToList('InFieldNames')
         
         # Traverse inputs and take maximum
         self._ValidateProgDataType(fldNms[0],executedObjects[fldNms[0]],'Fuzzy')
@@ -666,12 +666,12 @@ class FuzzyXOr(mpefp._MPilotEEMSFxnParent):
         self.fxnDesc['ShortDesc'] = 'Computes Fuzzy XOr: Truest - (Truest - 2nd Truest) * (2nd Truest - full False)/(Truest - full False)'
         self.fxnDesc['ReturnType'] = 'Fuzzy'
         
-        self.fxnDesc['ReqParams'] = {
+        self.fxnDesc['ReqArgs'] = {
             'InFieldNames':['Field Name List']
             }
-        self.fxnDesc['OptParams'] = {
+        self.fxnDesc['OptArgs'] = {
             'OutFileName':'File Name',
-            'MetaData':'Any',
+            'Metadata':'Any',
             'PrecursorFieldNames':['Field Name','Field Name List']
             }
         
@@ -680,7 +680,7 @@ class FuzzyXOr(mpefp._MPilotEEMSFxnParent):
     def Exec(self,executedObjects):
 
         self._ValidateListLen('InFieldNames',2)
-        fldNms = self._ParamToList('InFieldNames')
+        fldNms = self._ArgToList('InFieldNames')
         
         # Validate inputs
         for fldNm in fldNms:
@@ -744,12 +744,12 @@ class FuzzyNot(mpefp._MPilotEEMSFxnParent):
         self.fxnDesc['ShortDesc'] = 'Takes the fuzzy And (minimum) of fuzzy input variables'
         self.fxnDesc['ReturnType'] = 'Fuzzy'
         
-        self.fxnDesc['ReqParams'] = {
+        self.fxnDesc['ReqArgs'] = {
             'InFieldName':'Field Name'
             }
-        self.fxnDesc['OptParams'] = {
+        self.fxnDesc['OptArgs'] = {
             'OutFileName':'File Name',
-            'MetaData':'Any',
+            'Metadata':'Any',
             'PrecursorFieldNames':['Field Name','Field Name List']
             }
         
@@ -757,15 +757,15 @@ class FuzzyNot(mpefp._MPilotEEMSFxnParent):
 
     def DependencyNms(self):
         
-        rtrn = self._ParamToList('InFieldName')
-        rtrn += self._ParamToList('PrecursorFieldNames')
+        rtrn = self._ArgToList('InFieldName')
+        rtrn += self._ArgToList('PrecursorFieldNames')
         return rtrn
     
     # def DependencyNms(self):
 
     def Exec(self,executedObjects):
 
-        inFldNm = self.ParamByNm('InFieldName')
+        inFldNm = self.ArgByNm('InFieldName')
 
         self._ValidateProgDataType(inFldNm,executedObjects[inFldNm],'Fuzzy')
         self.execRslt = -executedObjects[inFldNm].ExecRslt()

--- a/eems_online_app/static/deps/mpilot/MPilotEEMSFxnParent.py
+++ b/eems_online_app/static/deps/mpilot/MPilotEEMSFxnParent.py
@@ -46,19 +46,19 @@ class _MPilotEEMSFxnParent(mpfp._MPilotFxnParent):
 
     # def __init__(self,mptCmdStruct=None):
 
-    def _ValidateProgDataType(self,paramNm,paramDatum,tgtTypes):
+    def _ValidateProgDataType(self,argNm,argDatum,tgtTypes):
 
         if not isinstance(tgtTypes,list): tgtTypes = [tgtTypes]
 
-        if paramDatum.DataType() not in tgtTypes:
+        if argDatum.DataType() not in tgtTypes:
             raise Exception(
                 '{}{}{}{}{}'.format(
                     '\n********************ERROR********************\n',
-                    'Parameter list has invalid type:\n',
-                    'Parameter name: {}  Should be one of: {}  Is: {}\n'.format(
-                        paramNm,
+                    'Argument list has invalid type:\n',
+                    'Argument name: {}  Should be one of: {}  Is: {}\n'.format(
+                        argNm,
                         tgtTypes,
-                        paramDatum.DataType(),
+                        argDatum.DataType(),
                         ),
                     'File: {}  Line number: {}\n'.format(
                         self.mptCmdStruct['cmdFileNm'],
@@ -69,7 +69,7 @@ class _MPilotEEMSFxnParent(mpfp._MPilotFxnParent):
                 ),
             )
 
-    # def _ValidateProgDataType(self,paramNm,parmDatum,type2):
+    # def _ValidateProgDataType(self,argNm,parmDatum,type2):
 
     def _ValidateIsDataLayer(self,mpObject):
 
@@ -89,47 +89,47 @@ class _MPilotEEMSFxnParent(mpfp._MPilotFxnParent):
                 ),
             )
 
-    # def _ValidateProgDataType(self,paramNm,parmDatum,type2):
+    # def _ValidateProgDataType(self,argNm,parmDatum,type2):
 
     def InitFromParsedCmd(self,parsedCmd):
         
         self.mptCmdStruct['parsedCmd'] = cp.deepcopy(parsedCmd)
         self.InitRawCmdFromParsedCmd()
         self.InitCleanCmdFromParsedCmd()
-        if 'DataType' in parsedCmd['params']:
-            self.dataType = parsedCmd['params']['DataType']
-        if 'IsDataLayer' in parsedCmd['params']:
-            self.isDataLayer = parsedCmd['params']['IsDataLayer']
+        if 'DataType' in parsedCmd['arguments']:
+            self.dataType = parsedCmd['arguments']['DataType']
+        if 'IsDataLayer' in parsedCmd['arguments']:
+            self.isDataLayer = parsedCmd['arguments']['IsDataLayer']
         
     # def InitFromParsedCmd(self,parsedCmd):
 
-    def ValFromParamByNm(self,paramNm):
+    def ValFromArgByNm(self,argNm):
 
         # Return an actual value (be that a single value or a list)
-        # of a parameter. Parameters are read as strings, so this
+        # of a argument. Arguments are read as strings, so this
         # converts that string into what it is supposed be. Right
         # now, it only does conversion on variables that are numeric.
-        # If there is an option for what the parameter can be, it
+        # If there is an option for what the argument can be, it
         # finds the most restrictive (e.g. integer instead of float)
-        # definition for the parameter and does the conversion based
+        # definition for the argument and does the conversion based
         # on that.
 
         rtrn = None
-        param = self.ParamByNm(paramNm)
+        arg = self.ArgByNm(argNm)
 
-        if param is None: return None
+        if arg is None: return None
 
-        # Get the legal param types for this parameter
-        if paramNm in self.fxnDesc['ReqParams']:
-            legalParamTypes = self.fxnDesc['ReqParams'][paramNm]
-        elif paramNm in self.fxnDesc['OptParams']:
-            legalParamTypes = self.fxnDesc['OptParams'][paramNm]
+        # Get the legal arg types for this argument
+        if argNm in self.fxnDesc['ReqArgs']:
+            legalArgTypes = self.fxnDesc['ReqArgs'][argNm]
+        elif argNm in self.fxnDesc['OptArgs']:
+            legalArgTypes = self.fxnDesc['OptArgs'][argNm]
         else:
             raise Exception(
                 '{}{}{}{}{}{}'.format(
                     '\n********************ERROR********************\n',
                     'Programming error:\n',
-                    '  Cannot find description of paramter: {}'.format(paramNm),
+                    '  Cannot find description of argter: {}'.format(argNm),
                     '  Check and correct the class definition of the MPilot command: {}\n'.format(
                         self.fxnDesc['Name']
                         ),
@@ -140,21 +140,21 @@ class _MPilotEEMSFxnParent(mpfp._MPilotFxnParent):
                     ),
                 )
 
-        # if paramNm self.fxnDesc['ReqParams']:
+        # if argNm self.fxnDesc['ReqArgs']:
 
         # From the choices it is allowed to be, find out
         # the most restrictive type that fits. Note,
         # order of checking matters here.
 
-        paramType = None
+        argType = None
         
-        if not isinstance(legalParamTypes, list):
+        if not isinstance(legalArgTypes, list):
             
-            paramType = legalParamTypes
+            argType = legalArgTypes
             
         else:
 
-            for simplestParamType in [
+            for simplestArgType in [
                 'Positive Integer',
                 'Integer',
                 'Positive Integer List',
@@ -166,25 +166,27 @@ class _MPilotEEMSFxnParent(mpfp._MPilotFxnParent):
                 'Float List',
                 'Positive Float List',
                 'Fuzzy Value List',
+                'Field Name',
+                'Field Name List'
                 ]:
 
-                # Check the options for this parameter
-                if simplestParamType in legalParamTypes:
+                # Check the options for this argument
+                if simplestArgType in legalArgTypes:
                     # is it this?
-                    if self._IsParamType(param,simplestParamType):
-                        paramType = simplestParamType
+                    if self._IsArgType(arg,simplestArgType):
+                        argType = simplestArgType
                         break
 
-        # if not isinstance(paramTypes, list):
+        # if not isinstance(argTypes, list):
 
-        if paramType is None:
+        if argType is None:
             raise Exception(
                 '{}{}{}{}{}{}{}'.format(
                     '\n********************ERROR********************\n',
-                    'Illegal parameter value(s): \n'.format(legalParamTypes),
-                    '  Parameter name: {}\n'.format(paramNm),
-                    '  Must be (one of): {}\n'.format(legalParamTypes),
-                    '  Value is: {}\n'.format(param),
+                    'Illegal argument value(s): \n'.format(legalArgTypes),
+                    '  Argument name: {}\n'.format(argNm),
+                    '  Must be (one of): {}\n'.format(legalArgTypes),
+                    '  Value is: {}\n'.format(arg),
                     'File: {}  Line number: {}\n'.format(
                         self.mptCmdStruct['cmdFileNm'],
                         self.mptCmdStruct['lineNo']
@@ -193,18 +195,18 @@ class _MPilotEEMSFxnParent(mpfp._MPilotFxnParent):
                     )
                 )
 
-        # List of the paramter values in string form
-        paramVals = param.replace('[','').replace(']','').split(',')
+        # List of the argter values in string form
+        argVals = arg.replace('[','').replace(']','').split(',')
 
         # Convert the string(s) into value(s)
-        if paramType in [
+        if argType in [
             'Integer',
             'Positive Integer',
             'Integer List',
             'Positive Integer List',
             ]:
-            rtrn = [int(x) for x in paramVals]
-        elif paramType in [
+            rtrn = [int(x) for x in argVals]
+        elif argType in [
             'Float',
             'Positive Float',
             'Fuzzy Value',
@@ -212,16 +214,16 @@ class _MPilotEEMSFxnParent(mpfp._MPilotFxnParent):
             'Positive Float List',
             'Fuzzy Value List',
             ]:
-            rtrn = [float(x) for x in paramVals]
-        elif paramType in [
+            rtrn = [float(x) for x in argVals]
+        elif argType in [
             'Truest Or Falsest'
             ]:
-            if (param == '-1' or
-                re.match(r'^[Ff][Aa][Ll][Ss][Ee][Ss][Tt]$',param)
+            if (arg == '-1' or
+                re.match(r'^[Ff][Aa][Ll][Ss][Ee][Ss][Tt]$',arg)
                 ):
                 rtrn = ['Falsest']
-            elif (param == '1' or
-                re.match(r'^[Tt][Rr][Uu][Ee][Ss][Tt]$',param)
+            elif (arg == '1' or
+                re.match(r'^[Tt][Rr][Uu][Ee][Ss][Tt]$',arg)
                 ):
                 rtrn = ['Truest']
             else:
@@ -229,19 +231,19 @@ class _MPilotEEMSFxnParent(mpfp._MPilotFxnParent):
                     'Programming error. Truest Or Falsest has value: {}\n'.format(inStr))
 
         else: # No conversion required
-            rtrn = paramVals
-        # if paramType in [...] elif...else
+            rtrn = argVals
+        # if argType in [...] elif...else
             
         # Convert to single value is type is not list
-        if paramType.find('List') < 0:
+        if argType.find('List') < 0:
             rtrn = rtrn[0]
 
         return rtrn
 
-    # def ValFromParamByNm(self,paramNm):
+    # def ValFromArgByNm(self,argNm):
 
     # Used to check validity of mptCmdStruct argument types
-    def _IsParamType(self,inStr,inType):
+    def _IsArgType(self,inStr,inType):
 
         if re.match(r'.+ List$',inType):
             theType = inType.replace(' List','',1)
@@ -273,13 +275,13 @@ class _MPilotEEMSFxnParent(mpfp._MPilotFxnParent):
                     if int(theStr) < 1:
                         return False
             elif theType == 'Float':
-                if not re.match(r'^[+-]{0,1}([0-9]+\.*[0-9]*)$|(^[+-]{0,1}\.[0-9]+)$',theStr):
+                if not re.match(r'^[+-]{0,1}([0-9]+\.*[0-9]*)(e[+-]{0,1}[0-9]+){0,1}$|(^[+-]{0,1}\.[0-9]+)(e[+-]{0,1}[0-9]+){0,1}$',theStr):
                     return False
             elif theType == 'Positive Float':
-                if not re.match(r'^[+]{0,1}([0-9]+\.*[0-9]*)$|(^[+-]{0,1}\.[0-9]+)$',theStr):
+                if not re.match(r'^[+]{0,1}([0-9]+\.*[0-9]*)(e[+-]{0,1}[0-9]+){0,1}$|(^[+-]{0,1}\.[0-9]+)(e[+-]{0,1}[0-9]+){0,1}$',theStr):
                     return False
             elif theType == 'Fuzzy Value':
-                if not re.match(r'^[+-]{0,1}([0-9]+\.*[0-9]*)$|(^[+-]{0,1}\.[0-9]+)$',theStr):
+                if not re.match(r'^[+-]{0,1}([0-9]+\.*[0-9]*)(e[+-]{0,1}[0-9]+){0,1}$|(^[+-]{0,1}\.[0-9]+)(e[+-]{0,1}[0-9]+){0,1}$',theStr):
                     return False
                 if not self.fuzzyMin <= float(theStr) <= self.fuzzyMax:
                     return False
@@ -310,14 +312,14 @@ class _MPilotEEMSFxnParent(mpfp._MPilotFxnParent):
                     '{}{}{}'.format(
                         '\n********************ERROR********************\n',
                         'Class definition error.\n',
-                        'Illegal parameter type in function descriptions: {}'.format(inType)
+                        'Illegal argument type in function descriptions: {}'.format(inType)
                         )
                     )
         # for theStr in theStrs:
 
         return True
     
-    # def _IsParamType(self,inStr,type):
+    # def _IsArgType(self,inStr,type):
 
     def _InsureFuzzy(self,arr):
         
@@ -329,56 +331,56 @@ class _MPilotEEMSFxnParent(mpfp._MPilotFxnParent):
         
     # def _InsureFuzzy(self,arr):
 
-    def _IsValidParamType(self,paramStr,paramTypes):
+    def _IsValidArgType(self,argStr,argTypes):
 
         rtrn = False
-        if not isinstance(paramTypes,list): paramTypes = [paramTypes]
+        if not isinstance(argTypes,list): argTypes = [argTypes]
             
-        for pType in paramTypes:
-            if self._IsParamType(paramStr,pType):
+        for pType in argTypes:
+            if self._IsArgType(argStr,pType):
                 rtrn = True
                 break
             
         return rtrn
     
-    # def _IsValidParamType(self,paramStr,paramTypes):
+    # def _IsValidArgType(self,argStr,argTypes):
 
-    def SetParam(self,paramNm,value):
+    def SetArg(self,argNm,value):
         
         # value must be string
-        if paramNm in self.fxnDesc['ReqParams']:
-            legalParamTypes = self.fxnDesc['ReqParams'][paramNm]
-        elif paramNm in self.fxnDesc['OptParams']:
-            legalParamTypes = self.fxnDesc['OptParams'][paramNm]
+        if argNm in self.fxnDesc['ReqArgs']:
+            legalArgTypes = self.fxnDesc['ReqArgs'][argNm]
+        elif argNm in self.fxnDesc['OptArgs']:
+            legalArgTypes = self.fxnDesc['OptArgs'][argNm]
         else:
             raise Exception(
                 '{}{}{}'.format(
                     '\n********************ERROR********************\n',
-                    'Trying to set non-existend parameter:\n',
-                    '  Parameter: {}  Value: {}'.format(paramNm,value),
+                    'Trying to set non-existend argument:\n',
+                    '  Argument: {}  Value: {}'.format(argNm,value),
                     ),
                 )
 
-        if not isinstance(legalParamTypes,list): legalParamTypes = [legalParamTypes]
+        if not isinstance(legalArgTypes,list): legalArgTypes = [legalArgTypes]
 
-        if not self._IsValidParamType(value,legalParamTypes):
+        if not self._IsValidArgType(value,legalArgTypes):
             raise Exception(
                 '{}{}{}{}'.format(
                     '\n********************ERROR********************\n',
-                    'Invalid value for parameter:\n',
-                    '  Parameter: {}  Value: {}'.format(paramNm,value),
-                    '  Value must be one of:\n    {}'.format('\n    '.join(legalParamTypes)),
+                    'Invalid value for argument:\n',
+                    '  Argument: {}  Value: {}'.format(argNm,value),
+                    '  Value must be one of:\n    {}'.format('\n    '.join(legalArgTypes)),
                     ),
                 )
 
-        self.mptCmdStruct['parsedCmd']['params'][paramNm] = cp.deepcopy(value)
+        self.mptCmdStruct['parsedCmd']['arguments'][argNm] = cp.deepcopy(value)
         
-    # def SetParam(self,paramNm,value):
+    # def SetArg(self,argNm,value):
         
     def DependencyNms(self):
         
-        rtrn = self._ParamToList('InFieldNames')
-        rtrn += self._ParamToList('PrecursorFieldNames')
+        rtrn = self._ArgToList('InFieldNames')
+        rtrn += self._ArgToList('PrecursorFieldNames')
         return rtrn
     
     # def DependencyNms(self):

--- a/eems_online_app/static/deps/mpilot/MPilotEEMSOnlineGraphicsLib.py
+++ b/eems_online_app/static/deps/mpilot/MPilotEEMSOnlineGraphicsLib.py
@@ -2,15 +2,11 @@ from __future__ import division
 import MPilotEEMSFxnParent as mpefp
 import numpy as np
 import copy as cp
-import matplotlib as mpl
-mpl.use('Agg')
 import matplotlib.pyplot as plt
+import matplotlib as mpl
 import tempfile as tf
 import os
 import re
-import gc
-import gdal
-driver = gdal.GetDriverByName("PNG")
 
 class HistoDist(mpefp._MPilotEEMSFxnParent):
 
@@ -30,12 +26,12 @@ class HistoDist(mpefp._MPilotEEMSFxnParent):
         self.fxnDesc['ShortDesc'] = 'Creates a histogram for a variable\'s distribution'
         self.fxnDesc['ReturnType'] = 'Boolean'
         
-        self.fxnDesc['ReqParams'] = {
+        self.fxnDesc['ReqArgs'] = {
             'InFieldName':'Field Name'
             }
-        self.fxnDesc['OptParams'] = {
+        self.fxnDesc['OptArgs'] = {
             'OutFileName':'File Name',
-            'MetaData':'Any',
+            'Metadata':'Any',
             'PrecursorFieldNames':['Field Name','Field Name List'],
             'XMin':'Float',
             'XMax':'Float',
@@ -48,30 +44,30 @@ class HistoDist(mpefp._MPilotEEMSFxnParent):
 
     def DependencyNms(self):
         
-        rtrn = self._ParamToList('InFieldName')
-        rtrn += self._ParamToList('PrecursorFieldNames')
+        rtrn = self._ArgToList('InFieldName')
+        rtrn += self._ArgToList('PrecursorFieldNames')
         return rtrn
     
     # def DependencyNms(self):
         
     def Exec(self,executedObjects):
-
-        dataObj = executedObjects[self.ValFromParamByNm('InFieldName')]
+        
+        dataObj = executedObjects[self.ValFromArgByNm('InFieldName')]
         self._ValidateIsDataLayer(dataObj)
 
-        outFNm = self.ParamByNm('OutFileName')
+        outFNm = self.ArgByNm('OutFileName')
 
         fig = plt.figure()
         ax1 = fig.add_subplot(111)
 
-        xMin = self.ValFromParamByNm('XMin')
+        xMin = self.ValFromArgByNm('XMin')
         if xMin is None:
             if dataObj.DataType() == 'Fuzzy':
                 xMin = self.fuzzyMin
             else:
                 xMin = dataObj.ExecRslt().min()
 
-        xMax = self.ValFromParamByNm('XMax')
+        xMax = self.ValFromArgByNm('XMax')
         if xMax is None:
             if dataObj.DataType() == 'Fuzzy':
                 xMax = self.fuzzyMax
@@ -79,26 +75,26 @@ class HistoDist(mpefp._MPilotEEMSFxnParent):
                 xMax = dataObj.ExecRslt().max()
 
         # YMax must be set if we are going to use y limits
-        yMax = self.ValFromParamByNm('YMax')
-        yMin = self.ValFromParamByNm('yMin')
+        yMax = self.ValFromArgByNm('YMax')
+        yMin = self.ValFromArgByNm('yMin')
         if yMax is not None:
             if yMin is None: yMin = 0.
             ax1.set_ylim(yMin,yMax)
 
-        if self.ValFromParamByNm('Color') is not None:
-            faceColor = self.ValFromParamByNm('Color')
+        if self.ValFromArgByNm('Color') is not None:
+            faceColor = self.ValFromArgByNm('Color')
         else:
             faceColor = 'grey'
 
-            hist = plt.hist(
-                dataObj.ExecRslt().ravel().compressed(),
-                bins=50,
-                range=(xMin,xMax),
-                facecolor = faceColor,
+        hist = plt.hist(
+            dataObj.ExecRslt().ravel().compressed(),
+            bins=50,
+            range=(xMin,xMax),
+            facecolor = faceColor,
             )
         ax1.set_xlabel('Value')
         ax1.set_ylabel('Count')
-        ax1.set_title('Distribution for {}'.format(self.ValFromParamByNm('InFieldName')))
+        ax1.set_title('Distribution for {}'.format(self.ValFromArgByNm('InFieldName')))
         
         if outFNm is None:
             outFNm = tf.mktemp(suffix='.png')
@@ -137,12 +133,12 @@ class RenderLayer(mpefp._MPilotEEMSFxnParent):
         self.fxnDesc['ShortDesc'] = 'Renders a layer'
         self.fxnDesc['ReturnType'] = 'Boolean'
         
-        self.fxnDesc['ReqParams'] = {
+        self.fxnDesc['ReqArgs'] = {
             'InFieldName':'Field Name',
             'OutFileName':'File Name',
             }
-        self.fxnDesc['OptParams'] = {
-            'MetaData':'Any',
+        self.fxnDesc['OptArgs'] = {
+            'Metadata':'Any',
             'PrecursorFieldNames':['Field Name','Field Name List'],
             'ColorMap':'Any',
             'Origin':'Any',
@@ -152,42 +148,18 @@ class RenderLayer(mpefp._MPilotEEMSFxnParent):
 
     def DependencyNms(self):
         
-        rtrn = self._ParamToList('InFieldName')
-        rtrn += self._ParamToList('PrecursorFieldNames')
+        rtrn = self._ArgToList('InFieldName')
+        rtrn += self._ArgToList('PrecursorFieldNames')
         return rtrn
     
     # def DependencyNms(self):
-
-    def Project(self, outFNm):
-
-            input_basename = outFNm.replace('.png','')
-            trans_tiff = input_basename + "_trans.tiff"
-            warp_tiff = input_basename + "_warp.tiff"
-            output_png = input_basename + ".png"
-
-            extent = self.ParamByNm('Extent')
-            epsg = self.ParamByNm('EPSG')
-
-            os.system("gdal_translate -a_ullr " + extent + " -a_srs EPSG:" + epsg + " " + outFNm + " " + trans_tiff )
-
-            os.system("gdalwarp -s_srs EPSG:" + epsg + " -t_srs EPSG:3857 " +  trans_tiff + " " + warp_tiff)
-
-            src_ds = gdal.Open(warp_tiff)
-
-            # Overwrite Matplotlib png
-            driver.CreateCopy(output_png, src_ds,0)
-
-            src_ds = None
-
-            os.remove(trans_tiff)
-            os.remove(warp_tiff)
         
     def Exec(self,executedObjects):
 
-        dataObj = executedObjects[self.ValFromParamByNm('InFieldName')]
+        dataObj = executedObjects[self.ValFromArgByNm('InFieldName')]
         self._ValidateIsDataLayer(dataObj)
 
-        outFNm = self.ParamByNm('OutFileName')
+        outFNm = self.ArgByNm('OutFileName')
 
         if dataObj.DataType() == 'Fuzzy':
             minVal = self.fuzzyMin
@@ -196,18 +168,15 @@ class RenderLayer(mpefp._MPilotEEMSFxnParent):
             minVal = dataObj.ExecRslt().min()
             maxVal = dataObj.ExecRslt().max()
 
-        map_quality = self.ParamByNm('MapQuality')
-        w = int(map_quality.split(',')[0])
-        h = int(map_quality.split(',')[1])
-        fig = plt.figure(figsize=(w,h))
+        fig = plt.figure()
         ax1 = fig.add_axes([0,0,1,1])
         ax1.axis('off')
 
-        cmap = self.ValFromParamByNm('ColorMap')
-        if cmap is None: cmap = 'RdYlBu_r'
-
-        origin = self.ParamByNm('Origin') if self.ParamByNm('Origin') is not None else 'lower'
-
+        cmap = self.ValFromArgByNm('ColorMap')
+        if cmap is None: cmap = 'RdYlBu'
+        
+        origin = self.ArgByNm('Origin') if self.ArgByNm('Origin') is not None else 'lower'
+                
         myImg = ax1.imshow(
             dataObj.ExecRslt(),
             aspect='auto',
@@ -216,15 +185,9 @@ class RenderLayer(mpefp._MPilotEEMSFxnParent):
             )
 
         myImg.set_cmap(cmap)
-
-        plt.gca().invert_yaxis()
-        plt.savefig(outFNm, transparent=True)
-        plt.close()
-        gc.collect()
-        plt.clf()
-
-        # Project MatPlotLib png to Web Mercator
-        self.Project(outFNm)
+        
+        plt.savefig(outFNm)
+        plt.close(fig)
 
         # now the key
         fig = plt.figure(figsize=(8,1))
@@ -241,9 +204,8 @@ class RenderLayer(mpefp._MPilotEEMSFxnParent):
         outFNm = re.sub(r'(\.[^\.]+)$',r'_key\1',outFNm)
         
         plt.savefig(outFNm)
-        plt.close()
-        gc.collect()
-
+        plt.close(fig)
+        
         # ax1 = fig.add_subplot(111)
 
         # if dataObj.DataType() == 'Fuzzy':
@@ -253,7 +215,7 @@ class RenderLayer(mpefp._MPilotEEMSFxnParent):
         #     minVal = dataObj.ExecRslt().min()
         #     maxVal = dataObj.ExecRslt().max()
 
-        # ax1.tick_params(
+        # ax1.tick_args(
         #         axis='both',
         #         which='both',
         #         bottom=False,
@@ -266,7 +228,7 @@ class RenderLayer(mpefp._MPilotEEMSFxnParent):
         #         labelright=False
         #         )
 
-        # origin = self.ParamByNm('Origin') if self.ParamByNm('Origin') is not None else 'lower'
+        # origin = self.ArgByNm('Origin') if self.ArgByNm('Origin') is not None else 'lower'
             
         # myImg = ax1.imshow(
         #     dataObj.ExecRslt(),
@@ -277,17 +239,17 @@ class RenderLayer(mpefp._MPilotEEMSFxnParent):
 
         # myImg.set_clim(minVal,maxVal)
 
-        # cmap = self.ValFromParamByNm('ColorMap')
+        # cmap = self.ValFromArgByNm('ColorMap')
         # if cmap is None: cmap = 'RdYlBu'
 
         # myImg.set_cmap(cmap)
 
         # # We don't want a title
-        # # ax1.set_title('{}'.format(self.ValFromParamByNm('InFieldName')))
+        # # ax1.set_title('{}'.format(self.ValFromArgByNm('InFieldName')))
 
         # # if DoSeparate key is not specified or is false, it will be printed
         
-        # if not self.ParamByNm('DoSeparateKey') == 'True':
+        # if not self.ArgByNm('DoSeparateKey') == 'True':
         #     cbar = fig.colorbar(myImg)
         
         # plt.savefig(outFNm)
@@ -299,9 +261,8 @@ class RenderLayer(mpefp._MPilotEEMSFxnParent):
         # plt.close(fig) # fig must be closed to get it out of memory
 
     # def Exec(self,executedObjects):
-
+    
 # class RenderLayer(mpefp._MPilotEEMSFxnParent):
-
 
 class ScatterXY(mpefp._MPilotEEMSFxnParent):
 
@@ -321,13 +282,13 @@ class ScatterXY(mpefp._MPilotEEMSFxnParent):
         self.fxnDesc['ShortDesc'] = 'Creates a scatter plot for two fields'
         self.fxnDesc['ReturnType'] = 'Boolean'
         
-        self.fxnDesc['ReqParams'] = {
+        self.fxnDesc['ReqArgs'] = {
             'XFieldName':'Field Name',
             'YFieldName':'Field Name'
             }
-        self.fxnDesc['OptParams'] = {
+        self.fxnDesc['OptArgs'] = {
             'OutFileName':'File Name',
-            'MetaData':'Any',
+            'Metadata':'Any',
             'PrecursorFieldNames':['Field Name','Field Name List'],
             }
         
@@ -335,20 +296,20 @@ class ScatterXY(mpefp._MPilotEEMSFxnParent):
 
     def DependencyNms(self):
         
-        rtrn = self._ParamToList('XFieldName') + self._ParamToList('YFieldName')
-        rtrn += self._ParamToList('PrecursorFieldNames')
+        rtrn = self._ArgToList('XFieldName') + self._ArgToList('YFieldName')
+        rtrn += self._ArgToList('PrecursorFieldNames')
         return rtrn
     
     # def DependencyNms(self):
         
     def Exec(self,executedObjects):
         
-        xDataObj = executedObjects[self.ValFromParamByNm('XFieldName')]
-        yDataObj = executedObjects[self.ValFromParamByNm('YFieldName')]
+        xDataObj = executedObjects[self.ValFromArgByNm('XFieldName')]
+        yDataObj = executedObjects[self.ValFromArgByNm('YFieldName')]
         self._ValidateIsDataLayer(xDataObj)
         self._ValidateIsDataLayer(yDataObj)
 
-        outFNm = self.ParamByNm('OutFileName')
+        outFNm = self.ArgByNm('OutFileName')
 
         fig = plt.figure()
         ax1 = fig.add_subplot(111)
@@ -370,15 +331,15 @@ class ScatterXY(mpefp._MPilotEEMSFxnParent):
         fig = plt.figure()
         ax1 = fig.add_subplot(111)
 
-        ax1.set_xlabel(self.ValFromParamByNm('XFieldName'))
-        ax1.set_ylabel(self.ValFromParamByNm('YFieldName'))
+        ax1.set_xlabel(self.ValFromArgByNm('XFieldName'))
+        ax1.set_ylabel(self.ValFromArgByNm('YFieldName'))
 
         ax1.set_xlim(xMinVal,xMaxVal)
         ax1.set_ylim(yMinVal,yMaxVal)
         
         ax1.set_title('{} vs {}'.format(
-            self.ValFromParamByNm('YFieldName'),
-            self.ValFromParamByNm('XFieldName')
+            self.ValFromArgByNm('YFieldName'),
+            self.ValFromArgByNm('XFieldName')
             )
             )
 
@@ -411,7 +372,7 @@ class ScatterXY(mpefp._MPilotEEMSFxnParent):
         executedObjects[self.RsltNm()] = self
         
         plt.close(fig) # fig must be closed to get it out of memory
-
+        
     # def Exec(self,executedObjects):
-
+    
 # class ScatterXY(mpefp._MPilotEEMSFxnParent):

--- a/eems_online_app/static/deps/mpilot/MPilotFramework.py
+++ b/eems_online_app/static/deps/mpilot/MPilotFramework.py
@@ -109,7 +109,7 @@ class MPilotFramework(object):
 
         return rtrn
     
-    # def GetAllFxnClassInfo(self,verbose=False):
+    # def GetAllFxnClassInfo(self):
 
     def GetAllFormattedFxnClassInfo(self):
         
@@ -123,5 +123,15 @@ class MPilotFramework(object):
     # def GetAllFxnClassInfo(self,verbose=False):
 
     def FxnNames(self): return sorted(self.pilotFxnClasses.keys())
+
+    def GetFxnFormattedClassInfo(self,pilotFxnNm):
+
+        rtrn = None
+        
+        if pilotFxnNm in self.pilotFxnClasses.keys():
+            with getattr(self.pilotFxnClasses[pilotFxnNm]['mod'],pilotFxnNm)() as fxn:
+                rtrn = fxn.FormattedFxnDesc()
+
+        return rtrn
     
 # class MPilotFramework(object):

--- a/eems_online_app/static/deps/mpilot/MPilotParseMetadata.py
+++ b/eems_online_app/static/deps/mpilot/MPilotParseMetadata.py
@@ -1,0 +1,327 @@
+#!/opt/local/bin/python
+
+from collections import OrderedDict
+import re
+
+def ParseMetadata(mdStr):
+
+    # These parsing functions will honor quoted strings
+    # with spaces and special characters.
+    
+    mdTokens = StripTerminalCommas(TokenizeWithQuotes(mdStr))
+    # for token in mdTokens:
+    #     print token
+    return ParseMetadataFromTokens(mdTokens,mdStr)[0]
+
+# def ParseMetadata(mdStr):
+
+def ParseMetadataFromTokens(mdTokens,mdStr,tokenNdx=0):
+
+    # The idea here is that next token will be used to
+    # determine if the current token is legal
+    # if not, an error is thrown
+
+    # each token is in a tuple with an index to mdStr, so
+    # that when an error is thrown, the location in the mdStr
+    # can be given. 
+
+    # Check for balanced brackets
+    if [x for x in mdTokens].count('[') != [x for x in mdTokens].count(']'):
+        raise Exception(
+            '{}{}{}{}{}\n'.format(
+                '\n********************ERROR********************\n',
+                'Illegal metadata:\n\n',
+                '  Unbalanced brackets: number of "[" should match number of "]"\n\n',
+                '  Full metadata definition:\n',
+                '{}\n\n'.format(mdStr),
+                )
+            )
+    
+    mdDict = OrderedDict()
+
+    if not IsTokenType(mdTokens[tokenNdx],'['):
+        raise Exception(
+            '{}{}{}{}{}{}\n'.format(
+                '\n********************ERROR********************\n',
+                'Illegal metadata:\n\n',
+                '  Expected: "["\n',
+                '  Got: "{}"\n\n'.format(mdTokens[tokenNdx][0]),
+                '  Full metadata definition:\n',
+                '{}\n\n'.format(mdStr),
+                )
+            )
+    else:
+        crntTokenType = '['
+        crntTokenNdx = tokenNdx
+        crntToken = mdTokens[crntTokenNdx]
+
+    # if not IsTokenType(mdTokens[tokenNdx][0],'['):
+
+    # Go through the tokens building the dict and trapping errors
+    while crntTokenNdx < len(mdTokens):
+
+        # is this the last token
+        if crntTokenNdx + 1 < len(mdTokens):
+            nextToken = mdTokens[crntTokenNdx+1]
+        else:
+            nextToken = None
+
+        # check for unclosed metadata string
+        if crntTokenNdx is None and not crntTokenType != ']':
+            raise Exception(
+                '{}{}{}{}{}\n'.format(
+                    '\n********************ERROR********************\n',
+                    'Illegal metadata:\n',
+                    '  Metadata string not closed. May be missing "]"\n'
+                    '  Full metadata definition:\n'
+                    '{}\n\n'.format(mdStr),
+                    )
+                )
+        
+        if crntTokenType == '[':
+
+            if IsTokenType(nextToken,'key'):
+                crntTokenNdx = crntTokenNdx + 1
+                crntTokenType = 'key'
+                crntToken = mdTokens[crntTokenNdx]
+                continue
+            else:
+                raise Exception(
+                    '{}{}{}{}\n'.format(
+                        '\n********************ERROR********************\n',
+                        'Metadata error! Metadata key must follow "["\n',
+                        '  Full metadata definition:\n\n',
+                        '{}\n\n'.format(mdStr)
+                        )
+                    )
+            
+        elif crntTokenType == 'key':
+
+            if IsTokenType(nextToken,':'):
+                mdKey = crntToken
+                crntTokenNdx = crntTokenNdx + 1
+                crntTokenType = ':'
+                crntToken = mdTokens[crntTokenNdx]
+                continue
+            else:
+                raise Exception(
+                    '{}{}{}{}\n'.format(
+                        '\n********************ERROR********************\n',
+                        'Metadata error! ":" must follow metadata key: "{}"\n\n'.format(crntToken) ,
+                        '  Full metadata definition:\n\n',
+                        '{}\n\n'.format(mdStr)
+                        )
+                    )
+
+        elif crntTokenType == ':':
+            if IsTokenType(nextToken,'value'):
+                crntTokenNdx = crntTokenNdx + 1
+                crntTokenType = 'value'
+                crntToken = mdTokens[crntTokenNdx]
+                mdDict[mdKey] = crntToken
+                mdKey = None
+                continue
+            elif IsTokenType(nextToken,'['):
+                mdDict[mdKey],crntTokenNdx = \
+                  ParseMetadataFromTokens(mdTokens,mdStr,tokenNdx=crntTokenNdx+1)
+                crntTokenType = 'value'
+                crntToken = mdTokens[crntTokenNdx]
+                mdKey = None
+                continue
+            else:
+                raise Exception(
+                    '{}{}{}{}\n'.format(
+                        '\n********************ERROR********************\n',
+                        'Metadata error! Metadata Value or "[" must follow : "{}"\n\n'.format(crntToken) ,
+                        '  Full metadata definition:\n\n',
+                        '{}\n\n'.format(mdStr)
+                        )
+                    )
+            
+        elif crntTokenType == 'value':
+
+            if nextToken == None:
+                return mdDict, None
+            elif IsTokenType(nextToken,','):
+                crntTokenNdx = crntTokenNdx + 1
+                crntTokenType = ','
+                crntToken = mdTokens[crntTokenNdx]
+                continue
+            elif IsTokenType(nextToken,']'):
+                crntTokenNdx = crntTokenNdx + 1
+                crntTokenType = ']'
+                crntToken = mdTokens[crntTokenNdx]
+                continue
+            else:
+                raise Exception(
+                    '{}{}{}{}\n'.format(
+                        '\n********************ERROR********************\n',
+                        'Metadata error! "," or "]" must follow meta data value "{}"\n\n'.format(crntToken) ,
+                        '  Full metadata definition:\n\n',
+                        '{}\n\n'.format(mdStr)
+                        )
+                    )
+            
+        elif crntTokenType == ',':
+            
+            if IsTokenType(nextToken,'key'):
+                crntTokenNdx = crntTokenNdx + 1
+                crntTokenType = 'key'
+                crntToken = mdTokens[crntTokenNdx]
+                continue
+            else:
+                raise Exception(
+                    '{}{}{}{}\n'.format(
+                        '\n********************ERROR********************\n',
+                        'Metadata error! Metadata key must follow ","\n',
+                        '  Full metadata definition:\n\n',
+                        '{}\n\n'.format(mdStr)
+                        )
+                    )
+            
+        elif crntTokenType == ']':
+
+            if nextToken is None: # End of metadata
+                return mdDict, None
+            elif IsTokenType(nextToken,',') or IsTokenType(nextToken,']'):
+                crntTokenNdx = crntTokenNdx + 1
+                continue
+            else:
+                raise Exception(
+                    '{}{}{}{}\n'.format(
+                        '\n********************ERROR********************\n',
+                        'Metadata error! "]" or "," key must follow "]"\n',
+                        '  Full metadata definition:\n\n',
+                        '{}\n\n'.format(mdStr)
+                        )
+                    )
+
+    # while len(mdTokens) > 0:
+
+    # Because the ']' causes a return from the function,
+    # there is an error if we get here
+
+    raise Exception(
+        '{}{}{}\n'.format(
+            '\n********************ERROR********************\n',
+            'Metadata missing closing bracket: "]"\n',
+            'Metadata string is {}\n'.format(mdStr)
+            )
+        )
+
+# def ParseMetadataFromTokens(mdTokens,mdStr):
+
+def IsTokenInTypes(token,types):
+
+    rtrn = False
+    for type in types:
+        if IsTokenType(token,type):
+            rtrn = True
+    return rtrn
+
+# def IsTokenInTypes(token,types)
+    
+def IsTokenType(token,type):
+
+    reservedChars = ['[',':',',',']']
+    rtrn = False
+    
+    if type in reservedChars:
+        rtrn = token == type
+    elif type in ['key','value']:
+        # if it contains non whitespace, it is valid
+        if token[0] not in reservedChars and \
+          re.search('[^\s]',token) is not None:
+            rtrn = True
+
+    return rtrn
+    
+# def IsTokenType(token,types):
+
+def TokenizeWithQuotes(inStr):
+
+    '''
+    This routine will preserve quoted strings with any characters in them.
+    Note: Multiple white space in metadata will be converted into a
+    single space.
+    '''
+    # Split out quoted strings. Odd # strings => even # quotes
+
+    splitStr = inStr.split('"')
+
+    if len(splitStr) %2 != 1:
+        raise Exception('Unmatched quotes in command:\n{}\n'.format(mdStr))
+
+    tokens = []
+
+    for ndx in range(len(splitStr)):
+        if ndx%2 == 0:
+            tokens += TokenizeString(splitStr[ndx])
+        else:
+            tokens.append(re.sub(r'\s+',' ','"{}"'.format(splitStr[ndx])))
+
+    return tokens
+
+# def TokenizeMetadata(mdStr):
+
+def TokenizeString(inStr):
+
+    '''
+    Because for the life of me, I cannot figure out how to
+    include the newline properly in re.match, I'm preconverting
+    newlines into spaces.
+
+    Whitespace is used as a separator for tokens when it is not
+    padding a special character. e.g. "This = x y" will be converted
+    to ['This','=','x','y']
+    '''
+    inStr = re.sub(r'[\n\r]+',' ',inStr)
+    
+    singleCharTokens = ['\[','\]','\(','\)',',','=',':']
+    singleCharTokensStr = ''.join(singleCharTokens)
+
+    # Pull off leading characters
+    
+    tokens = []
+
+    while len(inStr) > 0:
+        
+        for tok in singleCharTokens:
+            # can we pull off a single character token
+            tokMatch = re.match(r'\s*({})\s*(.*)$'.format(tok),inStr)
+            if tokMatch is not None: break
+            
+        # can we pull off a string token
+        if tokMatch is None:
+            tokMatch = re.match(r'\s*([^\s{}]+)\s*(.*)$'.format(singleCharTokensStr),inStr)
+
+        if tokMatch is not None:
+            tokens.append(tokMatch.groups()[0])
+            inStr = tokMatch.groups()[1]
+            
+        else:
+            # Error check or return
+            if re.match(r'^\s*$',inStr) is not None:
+                raise Exception(
+                    '{}{}{}{}'.format(
+                        '\n********************ERROR********************\n',
+                        'Programming error: cannot parse string:\n',
+                        '{}\n'.format(inStr)
+                        )
+                    )
+
+    # while len(inStr) > 0:
+
+    return tokens
+
+# def TokenizeString(inStr):
+
+def StripTerminalCommas(inTokens):
+
+    for ndx in list(reversed(range(len(inTokens)-1))):
+        if inTokens[ndx] == ',' and inTokens[ndx+1] in [']',')']:
+            inTokens.pop(ndx)
+
+    return inTokens
+
+# def StripTerminalCommas(inTokens)

--- a/eems_online_app/static/deps/mpilot/MPilotProgram.py
+++ b/eems_online_app/static/deps/mpilot/MPilotProgram.py
@@ -52,6 +52,7 @@ class MPilotProgram(object):
         # dependency
 
         for rsltNm,mpCmd in self.unorderedMPCmds.items():
+
             if mpCmd.DependencyNms() is not None:
                 if not set(mpCmd.DependencyNms()).issubset(set(self.unorderedMPCmds)):
                     raise Exception(
@@ -297,9 +298,8 @@ class MPilotProgram(object):
         
         if self.orderedMPCmds is None:
             self._OrderCmds()
-        print self.orderedMPCmds.items()
+            
         for mpCmdNm,mpCmd in self.orderedMPCmds.items():
-            print mpCmd.CleanCmdStr()
             mpCmd.Exec(self.rslts)
 
     def Rslts(self):
@@ -308,7 +308,12 @@ class MPilotProgram(object):
             rtrn[rsltKey] = rsltObj.ExecRslt()
         return rtrn
 
+    def RsltByNm(self,nm):
+        return self.rslts[nm].ExecRslt()
+
     def CmdByNm(self,nm):
         return self.unorderedMPCmds[nm]
+
+    def ClearRslts(self): self.rslts = {}
 
 # class MPilotProgram(object):


### PR DESCRIPTION
Made changes to add metadata to MPilot script function arguments. Changed the term parameter to argument throughout code, so now the one and only way to refer to arguments in an MPilot script is argument.

Note: MPilotEEMSOnlineGraphicsLib.py needs to be merged with the one in the main branch. All other files will hopefully work as replacements in the main branch.